### PR TITLE
[DCB][OPS-11589][OPS-11608] lockout, ecospend stub

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val test = Seq(
     "com.typesafe"         % "config"            % "1.4.3"    % Test,
     "com.vladsch.flexmark" % "flexmark-all"      % "0.62.2"   % Test,
-    "org.scalatest"       %% "scalatest"         % "3.2.17"   % Test,
+    "org.scalatest"       %% "scalatest"         % "3.2.18"   % Test,
     "org.scalatestplus"   %% "selenium-4-12"     % "3.2.17.0" % Test,
     "io.cucumber"         %% "cucumber-scala"    % "8.20.0"   % Test,
     "io.cucumber"          % "cucumber-junit"    % "7.15.0"   % Test,

--- a/src/test/resources/features/BankTransfer.feature
+++ b/src/test/resources/features/BankTransfer.feature
@@ -11,15 +11,15 @@ Feature: Bank Transfer Journey
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
 
   Scenario: User completes a bank transfer and visits the income tax helpline
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -35,16 +35,16 @@ Feature: Bank Transfer Journey
     Then I am on the verifying account page
     When I navigate to test-only and select request success
     Then I am on the bank transfer request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
     When I click the link call or write to the Income Tax helpline
     Then I am on the income tax page in a new tab
 
   Scenario: User completes a bank transfer and decides to give feedback
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -60,17 +60,17 @@ Feature: Bank Transfer Journey
     Then I am on the verifying account page
     When I navigate to test-only and select request success
     Then I am on the bank transfer request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
     When I click the link what did you think of this service
 #    Then I am on the feedback page
 
   @a11y @zap
   Scenario: User completes a bank transfer and clicks back
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -86,17 +86,17 @@ Feature: Bank Transfer Journey
     Then I am on the verifying account page
     When I navigate to test-only and select request success
     Then I am on the bank transfer request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
     When I click browser back
 #    Then I am on the bank transfer request received page
-#    And The page contains P800REFNO1
+#    And The page contains 1234567890
 
   Scenario: User's bank is not listed and they apply for cheque instead
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -107,14 +107,14 @@ Feature: Bank Transfer Journey
     Then I am on the complete your refund request page
     When I click to submit refund request
     Then I am on the cheque request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
 
   Scenario: User chooses to apply for cheque from the give permission page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -128,14 +128,14 @@ Feature: Bank Transfer Journey
     Then I am on the complete your refund request page
     When I click to submit refund request
     Then I am on the cheque request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
 
   Scenario: User's refund request is not submitted so applies for cheque instead
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -159,15 +159,15 @@ Feature: Bank Transfer Journey
     Then I am on the complete your refund request page
     When I click to submit refund request
     Then I am on the cheque request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
 
   @a11y @zap
   Scenario: User's refund request is not submitted so they click back
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -189,11 +189,11 @@ Feature: Bank Transfer Journey
 #    Then I am on the refund request not submitted page
 
   Scenario: User decides to change bank account from the give permission page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue

--- a/src/test/resources/features/BankTransfer.feature
+++ b/src/test/resources/features/BankTransfer.feature
@@ -28,6 +28,8 @@ Feature: Bank Transfer Journey
     Then I am on the give your permission page
     And The first paragraph contains Chase
     When I click to approve the refund
+    Then I am on the bank stub page
+    When I select Authorised and click continue
     Then I am on the verifying account page
     When I click the link refresh this page
     Then I am on the verifying account page
@@ -51,6 +53,8 @@ Feature: Bank Transfer Journey
     Then I am on the give your permission page
     And The first paragraph contains Monzo Business
     When I click to approve the refund
+    Then I am on the bank stub page
+    When I select Authorised and click continue
     Then I am on the verifying account page
     When I click the link refresh this page
     Then I am on the verifying account page
@@ -75,6 +79,8 @@ Feature: Bank Transfer Journey
     Then I am on the give your permission page
     And The first paragraph contains Santander Personal
     When I click to approve the refund
+    Then I am on the bank stub page
+    When I select Authorised and click continue
     Then I am on the verifying account page
     When I click the link refresh this page
     Then I am on the verifying account page
@@ -140,6 +146,8 @@ Feature: Bank Transfer Journey
     Then I am on the give your permission page
     And The first paragraph contains Chase
     When I click to approve the refund
+    Then I am on the bank stub page
+    When I select Failed and click continue
     Then I am on the verifying account page
     When I click the link refresh this page
     Then I am on the verifying account page
@@ -170,6 +178,8 @@ Feature: Bank Transfer Journey
     Then I am on the give your permission page
     And The first paragraph contains Chase
     When I click to approve the refund
+    Then I am on the bank stub page
+    When I select Failed and click continue
     Then I am on the verifying account page
     When I click the link refresh this page
     Then I am on the verifying account page
@@ -201,3 +211,5 @@ Feature: Bank Transfer Journey
   Scenario: User checks for NINO
     When I click the dropdown link find a lost National Insurance number
     Then I am on the lost national insurance number page in a new tab
+
+  #TODO: click cancelled on bank stub

--- a/src/test/resources/features/ChangeAnswers.feature
+++ b/src/test/resources/features/ChangeAnswers.feature
@@ -13,21 +13,21 @@ Feature: Changing Answers
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
     When I click to change reference
     Then I am on the what is your reference for cheque page
     When I click to continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
     When I click to change nino
     Then I am on the what is your national insurance number for cheque page
     When I click to continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
 
   Scenario: Cheque journey answers can be changed
     When I select no I want a cheque and click continue
@@ -35,20 +35,20 @@ Feature: Changing Answers
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
     When I click to change reference
     Then I am on the what is your reference for cheque page
-    When I change the reference input to P800REFChanged and click continue
+    When I change the reference input to 234567890 and click continue
     Then I am on the check answers for cheque page
     When I click to change nino
     Then I am on the what is your national insurance number for cheque page
-    When I change the national insurance number input to BB000000B and click continue
+    When I change the national insurance number input to BB999999B and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with the changed answers with NINO BB000000B
+    And The page has rows for just reference and NINO with the changed answers with NINO BB999999B
 
   Scenario: Bank transfer journey answers are saved when revisiting pages
     Then I am on the do you want a bank transfer page
@@ -57,28 +57,28 @@ Feature: Changing Answers
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to change reference
     Then I am on the what is your reference for bank transfer page
     When I click to continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to change nino
     Then I am on the what is your national insurance number for bank transfer page
     When I click to continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to change date of birth
     Then I am on the what is your date of birth page
     When I click to continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
 
   Scenario: Bank transfer journey answers can be changed
     Then I am on the do you want a bank transfer page
@@ -87,23 +87,23 @@ Feature: Changing Answers
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to change reference
     Then I am on the what is your reference for bank transfer page
-    When I change the reference input to P800REFChanged and click continue
+    When I change the reference input to 234567890 and click continue
     Then I am on the check answers for bank transfer page
     When I click to change nino
     Then I am on the what is your national insurance number for bank transfer page
-    When I change the national insurance number input to BB000000B and click continue
+    When I change the national insurance number input to BB999999B and click continue
     Then I am on the check answers for bank transfer page
     When I click to change date of birth
     Then I am on the what is your date of birth page
     When I change the date of birth input to 10 10 1990 and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with the changed answers with NINO BB000000B
+    And The page has rows for reference, NINO and DOB with the changed answers with NINO BB999999B

--- a/src/test/resources/features/Cheque.feature
+++ b/src/test/resources/features/Cheque.feature
@@ -11,59 +11,59 @@ Feature: Cheque Journey
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
 
   Scenario: User completes a request for a cheque and visits the income tax helpline
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for cheque page
     When I click to continue
     Then I am on the complete your refund request page
     When I click to submit refund request
     Then I am on the cheque request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
     When I click the link call or write to the Income Tax helpline
     Then I am on the income tax page in a new tab
 
   Scenario: User completes a request for a cheque and decides to give feedback
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for cheque page
     When I click to continue
     Then I am on the complete your refund request page
     When I click to submit refund request
     Then I am on the cheque request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
     When I click the link what did you think of this service
     Then I am on the feedback page
     # test to be adjusted when feedback page created
 
   @a11y @zap
   Scenario: User completes a request for a cheque and clicks back
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for cheque page
     When I click to continue
     Then I am on the complete your refund request page
     When I click to submit refund request
     Then I am on the cheque request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
     When I click browser back
     Then I am on the cheque request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
 
   @a11y
   Scenario: User changes address for their cheque
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for cheque page
     When I click to continue

--- a/src/test/resources/features/Ecospend.feature
+++ b/src/test/resources/features/Ecospend.feature
@@ -1,0 +1,36 @@
+@test @jenkins
+Feature: Ecospend APIs
+
+  Scenario Outline: Consent API fails
+    Given I start a journey
+    Then I am on the do you want to sign in page
+    When I select not signed in and click continue
+    Then I am on the do you want a bank transfer page
+    When I select yes, bank transfer and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I enter AA000000A in the national insurance number input and click continue
+    Then I am on the what is your date of birth page
+    When I enter 01 01 2000 in the date of birth input and click continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    When I click to continue
+    Then I am on the we have confirmed your identity for bank transfer page
+    When I click to continue
+    Then I am on the what is the name of your bank page
+    When I enter Test | <error bank> in the bank input and click continue
+    Then I am on the give your permission page
+    And The first paragraph contains Test | <error bank>
+    When I click to approve the refund
+    Then I am on the technical difficulties page
+    Examples:
+     | error bank                |
+     | Bad Request               |
+     | Unauthorized 401          |
+     | Internal Server Error 500 |
+     | Bad Gateway 502           |
+     | Service Unavailable 503   |

--- a/src/test/resources/features/Ecospend.feature
+++ b/src/test/resources/features/Ecospend.feature
@@ -11,13 +11,13 @@ Feature: Ecospend APIs
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue

--- a/src/test/resources/features/IdentityNotConfirmed.feature
+++ b/src/test/resources/features/IdentityNotConfirmed.feature
@@ -43,6 +43,8 @@ Feature: Identity Verification Fails
     Then I am on the give your permission page
     And The first paragraph contains Chase
     When I click to approve the refund
+    Then I am on the bank stub page
+    When I select Authorised and click continue
     Then I am on the verifying account page
     When I click the link refresh this page
     Then I am on the verifying account page
@@ -125,5 +127,3 @@ Feature: Identity Verification Fails
     When I select bank transfer using your Government Gateway user ID and click continue
     Then I am on the auth login page
     And The redirect url contains /tax-you-paid/choose-year
-
-  #TODO: add tests for the lockout page when it connected to the journey

--- a/src/test/resources/features/IdentityNotConfirmed.feature
+++ b/src/test/resources/features/IdentityNotConfirmed.feature
@@ -14,11 +14,11 @@ Feature: Identity Verification Fails
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to choose another method
@@ -30,11 +30,11 @@ Feature: Identity Verification Fails
     Then I am on the what is your reference for bank transfer page
     When I click to continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I change the national insurance number input to AA000000A and click continue
+    When I change the national insurance number input to AB999999C and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -50,7 +50,7 @@ Feature: Identity Verification Fails
     Then I am on the verifying account page
     When I navigate to test-only and select request success
     Then I am on the bank transfer request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
 
   Scenario: Cheque user fails identity verification and logs in
     When I select no I want a cheque and click continue
@@ -58,11 +58,11 @@ Feature: Identity Verification Fails
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to choose another method
@@ -78,13 +78,13 @@ Feature: Identity Verification Fails
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to choose another method
@@ -96,16 +96,16 @@ Feature: Identity Verification Fails
     Then I am on the what is your reference for cheque page
     When I click to continue
     Then I am on the what is your national insurance number for cheque page
-    When I change the national insurance number input to AA000000A and click continue
+    When I change the national insurance number input to AB999999C and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO AA000000A
+    And The page has rows for just reference and NINO with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for cheque page
     When I click to continue
     Then I am on the complete your refund request page
     When I click to submit refund request
     Then I am on the cheque request received page
-    And The page contains P800REFNO1
+    And The page contains 1234567890
 
   Scenario: Bank transfer user fails identity verification and logs in
     When I select yes, bank transfer and click continue
@@ -113,13 +113,13 @@ Feature: Identity Verification Fails
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to choose another method
@@ -127,3 +127,5 @@ Feature: Identity Verification Fails
     When I select bank transfer using your Government Gateway user ID and click continue
     Then I am on the auth login page
     And The redirect url contains /tax-you-paid/choose-year
+
+  #TODO: tests for failed responses by check-reference API

--- a/src/test/resources/features/IdentityNotConfirmed.feature
+++ b/src/test/resources/features/IdentityNotConfirmed.feature
@@ -7,23 +7,6 @@ Feature: Identity Verification Fails
     When I select not signed in and click continue
     Then I am on the do you want a bank transfer page
 
-  Scenario: Cheque user fails identity verification and tries cheque again
-    When I select no I want a cheque and click continue
-    Then I am on the we need to confirm your identity for cheque page
-    And The page lists just reference and NINO
-    When I click to continue
-    Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
-    Then I am on the what is your national insurance number for cheque page
-    When I enter MA000003A in the national insurance number input and click continue
-    Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
-    When I click to continue
-    Then I am on the we cannot confirm your identity for cheque page
-    When I click to try again
-    Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
-
   @a11y @zap
   Scenario: Cheque user fails identity verification and completes a bank transfer
     When I select no I want a cheque and click continue
@@ -85,25 +68,6 @@ Feature: Identity Verification Fails
     When I select bank transfer using your Government Gateway user ID and click continue
     Then I am on the auth login page
     And The redirect url contains /tax-you-paid/choose-year
-
-  Scenario: Bank transfer user fails identity verification and tries bank transfer again
-    When I select yes, bank transfer and click continue
-    Then I am on the we need to confirm your identity for bank transfer page
-    And The page lists reference, NINO and DOB
-    When I click to continue
-    Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
-    Then I am on the what is your national insurance number for bank transfer page
-    When I enter MA000003A in the national insurance number input and click continue
-    Then I am on the what is your date of birth page
-    When I enter 01 01 2000 in the date of birth input and click continue
-    Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
-    When I click to continue
-    Then I am on the we cannot confirm your identity for bank transfer page
-    When I click to try again
-    Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
 
   @a11y @zap
   Scenario: Bank transfer user fails identity verification and completes a cheque journey

--- a/src/test/resources/features/LockedOut.feature
+++ b/src/test/resources/features/LockedOut.feature
@@ -292,3 +292,5 @@ Feature: Locked Out
     And The page has rows for reference, NINO and DOB with NINO MA000003A
     When I click to continue
     Then I am on the locked out for bank transfer page
+
+  #TODO: locked out returns to service

--- a/src/test/resources/features/LockedOut.feature
+++ b/src/test/resources/features/LockedOut.feature
@@ -13,21 +13,21 @@ Feature: Locked Out
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to try again
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to try again
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the locked out for cheque page
     When I click the link sign in to you HMRC online account
@@ -40,16 +40,16 @@ Feature: Locked Out
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to try again
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to choose another method
@@ -65,7 +65,7 @@ Feature: Locked Out
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the locked out for bank transfer page
 
@@ -75,11 +75,11 @@ Feature: Locked Out
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to choose another method
@@ -95,12 +95,12 @@ Feature: Locked Out
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to try again
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the locked out for bank transfer page
 
@@ -110,11 +110,11 @@ Feature: Locked Out
     And The page lists just reference and NINO
     When I click to continue
     Then I am on the what is your reference for cheque page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for cheque page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to choose another method
@@ -130,7 +130,7 @@ Feature: Locked Out
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to choose another method
@@ -144,7 +144,7 @@ Feature: Locked Out
     Then I am on the what is your national insurance number for cheque page
     When I click to continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the locked out for cheque page
 
@@ -154,23 +154,23 @@ Feature: Locked Out
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to try again
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to try again
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the locked out for bank transfer page
     When I click the link sign in to you HMRC online account
@@ -183,18 +183,18 @@ Feature: Locked Out
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to try again
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to choose another method
@@ -208,7 +208,7 @@ Feature: Locked Out
     Then I am on the what is your national insurance number for cheque page
     When I click to continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the locked out for cheque page
 
@@ -218,13 +218,13 @@ Feature: Locked Out
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to choose another method
@@ -238,12 +238,12 @@ Feature: Locked Out
     Then I am on the what is your national insurance number for cheque page
     When I click to continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to try again
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the locked out for cheque page
 
@@ -253,13 +253,13 @@ Feature: Locked Out
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter MA000003A in the national insurance number input and click continue
+    When I enter AB099999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for bank transfer page
     When I click to choose another method
@@ -273,7 +273,7 @@ Feature: Locked Out
     Then I am on the what is your national insurance number for cheque page
     When I click to continue
     Then I am on the check answers for cheque page
-    And The page has rows for just reference and NINO with NINO MA000003A
+    And The page has rows for just reference and NINO with NINO AB099999C
     When I click to continue
     Then I am on the we cannot confirm your identity for cheque page
     When I click to choose another method
@@ -289,7 +289,7 @@ Feature: Locked Out
     Then I am on the what is your date of birth page
     When I click to continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    And The page has rows for reference, NINO and DOB with NINO AB099999C
     When I click to continue
     Then I am on the locked out for bank transfer page
 

--- a/src/test/resources/features/LockedOut.feature
+++ b/src/test/resources/features/LockedOut.feature
@@ -1,0 +1,294 @@
+@test @jenkins
+Feature: Locked Out
+
+  Background:
+    Given I start a journey
+    Then I am on the do you want to sign in page
+    When I select not signed in and click continue
+    Then I am on the do you want a bank transfer page
+
+  Scenario: Cheque user fails identity verification three times and clicks to log in
+    When I select no I want a cheque and click continue
+    Then I am on the we need to confirm your identity for cheque page
+    And The page lists just reference and NINO
+    When I click to continue
+    Then I am on the what is your reference for cheque page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for cheque page
+    When I enter MA000003A in the national insurance number input and click continue
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for cheque page
+    When I click to try again
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for cheque page
+    When I click to try again
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the locked out for cheque page
+    When I click the link sign in to you HMRC online account
+    Then I am on the auth login page
+    And The redirect url contains /tax-you-paid/choose-year
+
+  Scenario: Cheque user fails identity verification twice and then fails bank transfer verification once
+    When I select no I want a cheque and click continue
+    Then I am on the we need to confirm your identity for cheque page
+    And The page lists just reference and NINO
+    When I click to continue
+    Then I am on the what is your reference for cheque page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for cheque page
+    When I enter MA000003A in the national insurance number input and click continue
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for cheque page
+    When I click to try again
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for cheque page
+    When I click to choose another method
+    Then I am on the choose another way to receive your refund from cheque page
+    When I select bank transfer logged out and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I click to continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I click to continue
+    Then I am on the what is your date of birth page
+    When I enter 01 01 2000 in the date of birth input and click continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the locked out for bank transfer page
+
+  Scenario: Cheque user fails identity verification and then fails bank transfer verification twice
+    When I select no I want a cheque and click continue
+    Then I am on the we need to confirm your identity for cheque page
+    And The page lists just reference and NINO
+    When I click to continue
+    Then I am on the what is your reference for cheque page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for cheque page
+    When I enter MA000003A in the national insurance number input and click continue
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for cheque page
+    When I click to choose another method
+    Then I am on the choose another way to receive your refund from cheque page
+    When I select bank transfer logged out and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I click to continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I click to continue
+    Then I am on the what is your date of birth page
+    When I enter 01 01 2000 in the date of birth input and click continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for bank transfer page
+    When I click to try again
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the locked out for bank transfer page
+
+  Scenario: Cheque user fails identity verification and then fails bank transfer verification and then cheque verification again
+    When I select no I want a cheque and click continue
+    Then I am on the we need to confirm your identity for cheque page
+    And The page lists just reference and NINO
+    When I click to continue
+    Then I am on the what is your reference for cheque page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for cheque page
+    When I enter MA000003A in the national insurance number input and click continue
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for cheque page
+    When I click to choose another method
+    Then I am on the choose another way to receive your refund from cheque page
+    When I select bank transfer logged out and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I click to continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I click to continue
+    Then I am on the what is your date of birth page
+    When I enter 01 01 2000 in the date of birth input and click continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for bank transfer page
+    When I click to choose another method
+    Then I am on the choose another way to receive your refund from bank transfer page
+    When I select cheque and click continue
+    Then I am on the we need to confirm your identity for cheque page
+    And The page lists just reference and NINO
+    When I click to continue
+    Then I am on the what is your reference for cheque page
+    When I click to continue
+    Then I am on the what is your national insurance number for cheque page
+    When I click to continue
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the locked out for cheque page
+
+  Scenario: Bank transfer user fails identity verification three times and clicks to log in
+    When I select yes, bank transfer and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I enter MA000003A in the national insurance number input and click continue
+    Then I am on the what is your date of birth page
+    When I enter 01 01 2000 in the date of birth input and click continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for bank transfer page
+    When I click to try again
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for bank transfer page
+    When I click to try again
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the locked out for bank transfer page
+    When I click the link sign in to you HMRC online account
+    Then I am on the auth login page
+    And The redirect url contains /tax-you-paid/choose-year
+
+  Scenario: Bank transfer user fails identity verification twice and then fails cheque verification once
+    When I select yes, bank transfer and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I enter MA000003A in the national insurance number input and click continue
+    Then I am on the what is your date of birth page
+    When I enter 01 01 2000 in the date of birth input and click continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for bank transfer page
+    When I click to try again
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for bank transfer page
+    When I click to choose another method
+    Then I am on the choose another way to receive your refund from bank transfer page
+    When I select cheque and click continue
+    Then I am on the we need to confirm your identity for cheque page
+    And The page lists just reference and NINO
+    When I click to continue
+    Then I am on the what is your reference for cheque page
+    When I click to continue
+    Then I am on the what is your national insurance number for cheque page
+    When I click to continue
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the locked out for cheque page
+
+  Scenario: Bank transfer user fails identity verification and then fails cheque verification twice
+    When I select yes, bank transfer and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I enter MA000003A in the national insurance number input and click continue
+    Then I am on the what is your date of birth page
+    When I enter 01 01 2000 in the date of birth input and click continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for bank transfer page
+    When I click to choose another method
+    Then I am on the choose another way to receive your refund from bank transfer page
+    When I select cheque and click continue
+    Then I am on the we need to confirm your identity for cheque page
+    And The page lists just reference and NINO
+    When I click to continue
+    Then I am on the what is your reference for cheque page
+    When I click to continue
+    Then I am on the what is your national insurance number for cheque page
+    When I click to continue
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for cheque page
+    When I click to try again
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the locked out for cheque page
+
+  Scenario: Bank transfer user fails identity verification and then fails cheque verification and then bank transfer verification again
+    When I select yes, bank transfer and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I enter P800REFNO1 in the reference input and click continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I enter MA000003A in the national insurance number input and click continue
+    Then I am on the what is your date of birth page
+    When I enter 01 01 2000 in the date of birth input and click continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for bank transfer page
+    When I click to choose another method
+    Then I am on the choose another way to receive your refund from bank transfer page
+    When I select cheque and click continue
+    Then I am on the we need to confirm your identity for cheque page
+    And The page lists just reference and NINO
+    When I click to continue
+    Then I am on the what is your reference for cheque page
+    When I click to continue
+    Then I am on the what is your national insurance number for cheque page
+    When I click to continue
+    Then I am on the check answers for cheque page
+    And The page has rows for just reference and NINO with NINO MA000003A
+    When I click to continue
+    Then I am on the we cannot confirm your identity for cheque page
+    When I click to choose another method
+    Then I am on the choose another way to receive your refund from cheque page
+    When I select bank transfer logged out and click continue
+    Then I am on the we need to confirm your identity for bank transfer page
+    And The page lists reference, NINO and DOB
+    When I click to continue
+    Then I am on the what is your reference for bank transfer page
+    When I click to continue
+    Then I am on the what is your national insurance number for bank transfer page
+    When I click to continue
+    Then I am on the what is your date of birth page
+    When I click to continue
+    Then I am on the check answers for bank transfer page
+    And The page has rows for reference, NINO and DOB with NINO MA000003A
+    When I click to continue
+    Then I am on the locked out for bank transfer page

--- a/src/test/resources/features/LoggedIn.feature
+++ b/src/test/resources/features/LoggedIn.feature
@@ -41,13 +41,13 @@ Feature: Logged In Journey
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -66,13 +66,13 @@ Feature: Logged In Journey
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue
@@ -94,13 +94,13 @@ Feature: Logged In Journey
     And The page lists reference, NINO and DOB
     When I click to continue
     Then I am on the what is your reference for bank transfer page
-    When I enter P800REFNO1 in the reference input and click continue
+    When I enter 1234567890 in the reference input and click continue
     Then I am on the what is your national insurance number for bank transfer page
-    When I enter AA000000A in the national insurance number input and click continue
+    When I enter AB999999C in the national insurance number input and click continue
     Then I am on the what is your date of birth page
     When I enter 01 01 2000 in the date of birth input and click continue
     Then I am on the check answers for bank transfer page
-    And The page has rows for reference, NINO and DOB with NINO AA000000A
+    And The page has rows for reference, NINO and DOB with NINO AB999999C
     When I click to continue
     Then I am on the we have confirmed your identity for bank transfer page
     When I click to continue

--- a/src/test/resources/features/LoggedIn.feature
+++ b/src/test/resources/features/LoggedIn.feature
@@ -111,6 +111,8 @@ Feature: Logged In Journey
     Then I am on the give your permission page
     And The first paragraph contains Chase
     When I click to approve the refund
+    Then I am on the bank stub page
+    When I select Authorised and click continue
     Then I am on the verifying account page
     When I click the link refresh this page
     Then I am on the verifying account page

--- a/src/test/resources/features/LoggedIn.feature
+++ b/src/test/resources/features/LoggedIn.feature
@@ -112,7 +112,7 @@ Feature: Logged In Journey
     And The first paragraph contains Chase
     When I click to approve the refund
     Then I am on the bank stub page
-    When I select Authorised and click continue
+    When I select Failed and click continue
     Then I am on the verifying account page
     When I click the link refresh this page
     Then I am on the verifying account page

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/ActionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/ActionSteps.scala
@@ -22,9 +22,8 @@ import uk.gov.hmrc.test.ui.pages._
 class ActionSteps extends BaseStepDef {
 
   Given("I start a journey") { () =>
-    driver.navigate.to(TestOnlyStartPage.url)
-    TestOnlyStartPage.assertPage()
-    clickByLinkText("drop failed attempts collection")
+    driver.navigate.to(TestOnlyClearAttemptsPage.url)
+    TestOnlyClearAttemptsPage.assertPage()
     driver.navigate.to(TestOnlyStartPage.url)
     TestOnlyStartPage.assertPage()
     clickByLinkText("start journey via gov-uk")

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/ActionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/ActionSteps.scala
@@ -39,6 +39,9 @@ class ActionSteps extends BaseStepDef {
       case "no I want a cheque"                                  => clickById("do-you-want-your-refund-via-bank-transfer-2")
       case "bank transfer using your Government Gateway user ID" => clickById("way-to-get-refund")
       case "cheque" | "bank transfer logged out"                 => clickById("way-to-get-refund-2")
+      case "Authorised"                                          => clickById("bank-result")
+      case "Cancelled"                                           => clickById("bank-result-2")
+      case "Failed"                                              => clickById("bank-result-3")
       case _                                                     => throw new Exception(option + " not found")
     }
     clickById("submit")

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/ActionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/ActionSteps.scala
@@ -114,6 +114,7 @@ class ActionSteps extends BaseStepDef {
       case "my bank is not listed"                         => clickById("myAccountIsNotListed")
       case "refresh this page"                             => clickById("refresh-this-page")
       case "Sign in using your Government Gateway user ID" => clickById("personal-tax-account-sign-in")
+      case "sign in to you HMRC online account"            => clickById("sign-in-to-you-hmrc-online-account")
       case "what did you think of this service"            => clickById("survey-link")
       case _                                               => throw new Exception(link + " not found")
     }

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/ActionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/ActionSteps.scala
@@ -24,6 +24,9 @@ class ActionSteps extends BaseStepDef {
   Given("I start a journey") { () =>
     driver.navigate.to(TestOnlyStartPage.url)
     TestOnlyStartPage.assertPage()
+    clickByLinkText("drop failed attempts collection")
+    driver.navigate.to(TestOnlyStartPage.url)
+    TestOnlyStartPage.assertPage()
     clickByLinkText("start journey via gov-uk")
     TestOnlyGovUkPage.assertPage()
     clickByLinkText("Claim Now >")

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AssertionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AssertionSteps.scala
@@ -45,6 +45,7 @@ class AssertionSteps extends BaseStepDef {
         eventually(WeCannotConfirmYourIdentityBankTransferLockedOutPage.assertPage())
       case "locked out for cheque"                                        => eventually(WeCannotConfirmYourIdentityChequeLockedOutPage.assertPage())
       case "refund request not submitted"                                 => eventually(RefundRequestNotSubmittedPage.assertPage())
+      case "technical difficulties"                                       => eventually(TechnicalDifficultiesPage.assertPage())
       case "verifying account"                                            => eventually(VerifyingBankAccountPage.assertPage())
       case "we cannot confirm your identity for bank transfer"            =>
         eventually(WeCannotConfirmYourIdentityBankTransferPage.assertPage())

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AssertionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AssertionSteps.scala
@@ -88,7 +88,7 @@ class AssertionSteps extends BaseStepDef {
       case "first paragraph" =>
         findTextByCssSelector(
           "p:nth-child(2)"
-        ) shouldBe s"By choosing approve, you will be redirected to $input to securely log in and approve your refund of £1,231.22. Change my bank."
+        ) shouldBe s"By choosing approve, you will be redirected to $input to securely log in and approve your refund of £4,321.09. Change my bank."
       case "page"            => findTextByCssSelector("div.govuk-panel__body") shouldBe s"Your P800 reference:\n$input"
       case "redirect url"    =>
         findElementById("redirectionUrl").getAttribute("value") shouldBe s"http://localhost:9416$input"
@@ -110,7 +110,7 @@ class AssertionSteps extends BaseStepDef {
   Then("^The page has rows for (.*) with NINO (.*)$") { (rows: String, nino: String) =>
     rows match {
       case "just reference and NINO"                          =>
-        findTextByCssSelector("dl > div:nth-child(1)") shouldBe s"P800 reference\nP800REFNO1\nChange\nP800 reference"
+        findTextByCssSelector("dl > div:nth-child(1)") shouldBe s"P800 reference\n1234567890\nChange\nP800 reference"
         findTextByCssSelector(
           "dl > div:nth-child(2)"
         )                                              shouldBe s"National insurance number\n$nino\nChange\nNational insurance number"
@@ -118,13 +118,13 @@ class AssertionSteps extends BaseStepDef {
       case "just reference and NINO with the changed answers" =>
         findTextByCssSelector(
           "dl > div:nth-child(1)"
-        )                          shouldBe s"P800 reference\nP800REFChanged\nChange\nP800 reference"
+        )                          shouldBe s"P800 reference\n234567890\nChange\nP800 reference"
         findTextByCssSelector(
           "dl > div:nth-child(2)"
         )                          shouldBe s"National insurance number\n$nino\nChange\nNational insurance number"
         isPresent("Date of birth") shouldBe false
       case "reference, NINO and DOB"                          =>
-        findTextByCssSelector("dl > div:nth-child(1)") shouldBe s"P800 reference\nP800REFNO1\nChange\nP800 reference"
+        findTextByCssSelector("dl > div:nth-child(1)") shouldBe s"P800 reference\n1234567890\nChange\nP800 reference"
         findTextByCssSelector(
           "dl > div:nth-child(2)"
         )                                              shouldBe s"National insurance number\n$nino\nChange\nNational insurance number"
@@ -134,7 +134,7 @@ class AssertionSteps extends BaseStepDef {
       case "reference, NINO and DOB with the changed answers" =>
         findTextByCssSelector(
           "dl > div:nth-child(1)"
-        ) shouldBe s"P800 reference\nP800REFChanged\nChange\nP800 reference"
+        ) shouldBe s"P800 reference\n234567890\nChange\nP800 reference"
         findTextByCssSelector(
           "dl > div:nth-child(2)"
         ) shouldBe s"National insurance number\n$nino\nChange\nNational insurance number"

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AssertionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AssertionSteps.scala
@@ -40,6 +40,9 @@ class AssertionSteps extends BaseStepDef {
       case "do you want to sign in"                                       => eventually(DoYouWantToSignInPage.assertPage())
       case "feedback"                                                     => eventually(FeedbackPage.assertPage())
       case "give your permission"                                         => eventually(GiveYourPermissionPage.assertPage())
+      case "locked out for bank transfer"                                 =>
+        eventually(WeCannotConfirmYourIdentityBankTransferLockedOutPage.assertPage())
+      case "locked out for cheque"                                        => eventually(WeCannotConfirmYourIdentityChequeLockedOutPage.assertPage())
       case "refund request not submitted"                                 => eventually(RefundRequestNotSubmittedPage.assertPage())
       case "verifying account"                                            => eventually(VerifyingBankAccountPage.assertPage())
       case "we cannot confirm your identity for bank transfer"            =>

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AssertionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AssertionSteps.scala
@@ -26,6 +26,7 @@ class AssertionSteps extends BaseStepDef {
   Then("^I am on the (.*) page$") { (page: String) =>
     page match {
       case "auth login"                                                   => eventually(AuthLoginPage.assertPage())
+      case "bank stub"                                                    => eventually(BankStubPage.assertPage())
       case "bank transfer request received"                               => eventually(BankTransferRequestReceivedPage.assertPage())
       case "change your address"                                          => eventually(ChangeYourDetailsPage.assertPage())
       case "check answers for bank transfer"                              => eventually(CheckAnswersBankTransferPage.assertPage())

--- a/src/test/scala/uk/gov/hmrc/test/ui/pages/Pages.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/pages/Pages.scala
@@ -124,6 +124,13 @@ object ChooseAnotherWayBankTransferPage extends BasePage {
   val title = "Bank transfer - choose another way to receive your refund"
 }
 
+object WeCannotConfirmYourIdentityBankTransferLockedOutPage extends BasePage {
+  val h1    = "We cannot confirm your identity"
+  val url   =
+    TestConfiguration.url("p800-refunds-frontend") + "/bank-transfer/no-more-attempts-left-to-confirm-your-identity"
+  val title = "Bank transfer - no more attempts left to confirm your identity"
+}
+
 object WeHaveConfirmedYourIdentityBankTransferPage extends BasePage {
   val h1    = "We have confirmed your identity"
   val url   = TestConfiguration.url("p800-refunds-frontend") + "/bank-transfer/your-identity-is-confirmed"
@@ -194,6 +201,12 @@ object ChooseAnotherWayChequePage extends BasePage {
   val h1    = "Choose another way to receive your refund"
   val url   = TestConfiguration.url("p800-refunds-frontend") + "/cheque/choose-another-way-to-receive-your-refund"
   val title = "Cheque - choose another way to receive your refund"
+}
+
+object WeCannotConfirmYourIdentityChequeLockedOutPage extends BasePage {
+  val h1    = "We cannot confirm your identity"
+  val url   = TestConfiguration.url("p800-refunds-frontend") + "/cheque/no-more-attempts-left-to-confirm-your-identity"
+  val title = "Cheque - no more attempts left to confirm your identity"
 }
 
 object WeHaveConfirmedYourIdentityChequePage extends BasePage {

--- a/src/test/scala/uk/gov/hmrc/test/ui/pages/Pages.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/pages/Pages.scala
@@ -149,6 +149,17 @@ object GiveYourPermissionPage extends BasePage {
   val title = "Bank transfer - give your permission"
 }
 
+object BankStubPage extends BasePage {
+  val h1    = "Bank Stub Page"
+  val url   = TestConfiguration.url("p800-refunds-frontend") + "/test-only/bank-page"
+  val title = ""
+  override def assertPage(): Unit = {
+    currentUrl           should include(url)
+    currentPageHeading shouldBe h1
+    currentPageTitle   shouldBe "Test Only - Get an Income Tax refund - GOV.UK"
+  }
+}
+
 object VerifyingBankAccountPage extends BasePage {
   val h1    = "We are verifying your bank account"
   val url   = TestConfiguration.url("p800-refunds-frontend") + "/bank-transfer/verifying-your-bank-account"

--- a/src/test/scala/uk/gov/hmrc/test/ui/pages/Pages.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/pages/Pages.scala
@@ -51,6 +51,14 @@ object TestOnlyStartPage extends BasePage {
   }
 }
 
+object TestOnlyClearAttemptsPage extends BasePage {
+  val h1                          = ""
+  val url                         = TestConfiguration.url("p800-refunds-frontend") + "/test-only/clear-attempts"
+  val title                       = ""
+  override def assertPage(): Unit =
+    currentUrl should include(url)
+}
+
 object TestOnlyGovUkPage extends BasePage {
   val h1    = "Tax overpayments and underpayments"
   val url   = TestConfiguration.url("p800-refunds-frontend") + "/test-only/gov-uk-route-in"

--- a/src/test/scala/uk/gov/hmrc/test/ui/pages/Pages.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/pages/Pages.scala
@@ -245,6 +245,12 @@ object FeedbackPage extends BasePage {
   val title = "Cheque - request received"
 }
 
+object TechnicalDifficultiesPage extends BasePage {
+  val h1    = "Sorry, we’re experiencing technical difficulties"
+  val url   = TestConfiguration.url("p800-refunds-frontend")
+  val title = "Sorry, we are experiencing technical difficulties - 500"
+}
+
 object AuthLoginPage extends BasePage {
   val h1    = "Authority Wizard"
   val url   =


### PR DESCRIPTION
- drop mongo collection at start of journey, so no accidental lockouts during test execution
- bank transfer tests now go through bank stub page
- new stub values used
- tests for lockout page
- tests for ecospend consent API failures